### PR TITLE
[RSA-2488] upgrade to imply 2.4.0 + scan query + psql

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,15 @@ EXPOSE 1527 2181 8081 8082 8083 8090 8091 8100 8101 8102 8103 8104 8105 8106 810
 
 WORKDIR /root/imply-$IMPLY_VERSION
 
+# this is for scan query on druid 0.10.1, remove when updating to 0.11.x (> 2.4.x)
+RUN cd /root/imply-$IMPLY_VERSION/dist/druid && \
+  java \
+    -cp "lib/*" \
+    -Ddruid.extensions.directory="extensions" \
+    -Ddruid.extensions.hadoopDependenciesDir="hadoop-dependencies" \
+    io.druid.cli.Main tools pull-deps \
+    --no-default-hadoop \
+    -c "io.druid.extensions.contrib:scan-query:0.10.1" && \
+ chown -R 501:staff extensions
+
 CMD ["bin/supervise", "-c", "conf/supervise/quickstart.conf"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 
 ARG IMPLY_VERSION
-RUN apt-get update && apt-get install -y cron wget && apt-get clean
+RUN apt-get update && apt-get install -y cron wget postgresql-client && apt-get clean
 
 RUN wget https://static.imply.io/release/imply-$IMPLY_VERSION.tar.gz && \
     tar -xzf /imply-$IMPLY_VERSION.tar.gz && \

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Dockerized version of the distribution available at https://imply.io/download.
 To build an image, first download the Imply distribution from the link above, place it in the cloned repository, and then run:
 
 ```
-export implyversion=2.2.3
+export implyversion=2.3.0
 tar -xzf imply-$implyversion.tar.gz
-docker build -t imply:$implyversion --build-arg implyversion=$implyversion .
+docker build -t imply:$implyversion --build-arg IMPLY_VERSION=$implyversion .
 ```
 
 To run the image in quickstart mode (single-machine, non-clustered):

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Dockerized version of the distribution available at https://imply.io/download.
 To build an image, first download the Imply distribution from the link above, place it in the cloned repository, and then run:
 
 ```
-export implyversion=2.3.0
+export implyversion=2.x.x
 tar -xzf imply-$implyversion.tar.gz
 docker build -t imply:$implyversion --build-arg IMPLY_VERSION=$implyversion .
 ```

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   environment:
-    IMPLY_VERSION: 2.3.0-PREVIEW8
+    IMPLY_VERSION: 2.3.0-PREVIEW15
   services:
     - docker
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   environment:
-    IMPLY_VERSION: 2.3.2
+    IMPLY_VERSION: 2.4.0-preview3
   services:
     - docker
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   environment:
-    IMPLY_VERSION: 2.3.1
+    IMPLY_VERSION: 2.3.2-preview
   services:
     - docker
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   environment:
-    IMPLY_VERSION: 2.3.0-PREVIEW16
+    IMPLY_VERSION: 2.3.0-PREVIEW18
   services:
     - docker
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   environment:
-    IMPLY_VERSION: 2.3.0-PREVIEW15
+    IMPLY_VERSION: 2.3.0-PREVIEW16
   services:
     - docker
 

--- a/circle.yml
+++ b/circle.yml
@@ -14,9 +14,4 @@ test:
     - aws configure set default.region us-west-2
     - eval "$(aws ecr get-login)"
     - docker build -t $AWS_ECR_REPOSITORY/$CIRCLE_PROJECT_REPONAME:$IMPLY_VERSION --build-arg IMPLY_VERSION=$IMPLY_VERSION .
-
-deployment:
-  stage:
-    branch: master
-    commands:
-      - ./shared/scripts/push-to-ecr.sh $IMPLY_VERSION
+    - ./shared/scripts/push-to-ecr.sh $IMPLY_VERSION

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   environment:
-    IMPLY_VERSION: 2.3.0
+    IMPLY_VERSION: 2.3.1
   services:
     - docker
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   environment:
-    IMPLY_VERSION: 2.3.0-PREVIEW18
+    IMPLY_VERSION: 2.3.0
   services:
     - docker
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   environment:
-    IMPLY_VERSION: 2.3.0-PREVIEW6
+    IMPLY_VERSION: 2.3.0-PREVIEW8
   services:
     - docker
 
@@ -17,6 +17,6 @@ test:
 
 deployment:
   stage:
-    branch: develop
+    branch: master
     commands:
       - ./shared/scripts/push-to-ecr.sh $IMPLY_VERSION

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   environment:
-    IMPLY_VERSION: 2.3.2-preview
+    IMPLY_VERSION: 2.3.2
   services:
     - docker
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   environment:
-    IMPLY_VERSION: 2.2.3
+    IMPLY_VERSION: 2.3.0-PREVIEW6
   services:
     - docker
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- [x] upgrade to 2.4.0, now it is doing from any branch rather than develop which is not even used
- [x] add scan query dependency so it does not take forever to build our imply image
- [x] add postgres client so we can drop the table from our container

## How was this tested?

will be tested together with our imply image

## Related Links
https://jira.ruckuswireless.com/browse/RSA-2488
